### PR TITLE
Add temporary arg to dbListTables and dbWriteTable to control temporary table behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ src/Makevars
 inst/include
 config.status
 a.out.dSYM
+[.].*.swp
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Suggests:
     RUnit (>= 0.4.22),
     roxygen2 (>= 3.0)
 License: LGPL (>= 2)
+URL: https://github.com/rstats-db/RSQLite
 Collate:
     'dbObjectId.R'
     'Object.R'

--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,12 @@
 Version 0.11.5
 
-- Include temporary tables in dbListTables()
-
 - Added Rstudio project file
 
 - Added select.cols capability to sqliteReadTable()
+
+- dbWriteTable and dbListTable have new temporary argument
+
+- new demo file temporary.R
 
 Version 0.11.4
 

--- a/R/ConnectionWrite.R
+++ b/R/ConnectionWrite.R
@@ -27,8 +27,8 @@ setMethod("dbWriteTable",
 setMethod("dbWriteTable",
   signature = signature(conn = "SQLiteConnection", name = "character",
     value="character"),
-  definition = function(conn, name, value, ...)
-    sqliteImportFile(conn, name, value, ...),
+  definition = function(conn, name, value, temporary = FALSE, ...)
+    sqliteImportFile(conn, name, value, temporary = FALSE, ...),
   valueClass = "logical"
 )
 
@@ -43,11 +43,12 @@ setMethod("dbWriteTable",
 #' @param field.types character vector of named  SQL field types where
 #'   the names are the names of new table's columns. If missing, types inferred
 #'   with \code{\link[DBI]{dbDataType}}).
+#' @param temporary logical which is TRUE if temporary table to be created and FALSE otherwise.
 #' @export
 #' @rdname dbWriteTable
 sqliteWriteTable <- function(con, name, value, row.names = TRUE, 
                              overwrite = FALSE, append = FALSE, 
-                             field.types = NULL, ...) {
+                             field.types = NULL, temporary = FALSE, ...) {
   if (overwrite && append)
     stop("overwrite and append cannot both be TRUE")
   
@@ -108,7 +109,7 @@ sqliteWriteTable <- function(con, name, value, row.names = TRUE,
   if (createTable) {
     sql <- dbBuildTableDefinition(new.con, name, value,
       field.types=field.types,
-      row.names=FALSE)
+      row.names=FALSE, temporary = temporary)
     success <- tryCatch({
       dbGetQuery(new.con, sql)
       TRUE
@@ -166,7 +167,7 @@ sqliteWriteTable <- function(con, name, value, row.names = TRUE,
 sqliteImportFile <- function(con, name, value, field.types = NULL, 
                              overwrite = FALSE, append = FALSE, header, 
                              row.names, nrows = 50, sep = ",", eol="\n", 
-                             skip = 0, ...) {
+                             skip = 0, temporary = FALSE, ...) {
   if(overwrite && append)
     stop("overwrite and append cannot both be TRUE")
   
@@ -221,7 +222,7 @@ sqliteImportFile <- function(con, name, value, field.types = NULL,
       stringsAsFactors=FALSE, ...)
     sql <-
       dbBuildTableDefinition(new.con, name, d, field.types = field.types,
-        row.names = row.names)
+        row.names = row.names, temporary = temporary)
     rs <- try(dbSendQuery(new.con, sql))
     if(inherits(rs, ErrorClass)){
       warning("could not create table: aborting sqliteImportFile")

--- a/demo/temporary.R
+++ b/demo/temporary.R
@@ -1,0 +1,14 @@
+library(RSQLite)
+con <- dbConnect(SQLite())
+
+# this is written as a temporary table
+dbWriteTable(con, "BOD", BOD, row.names = FALSE, temporary = TRUE)
+dbGetQuery(con, "select * from sqlite_master")
+dbGetQuery(con, "select * from sqlite_temp_master")
+dbRemoveTable(con, "BOD")
+
+# this is written as an ordinary table
+dbWriteTable(con, "BOD2", BOD, row.names = FALSE)
+dbGetQuery(con, "select * from sqlite_master")
+dbGetQuery(con, "select * from sqlite_temp_master")
+

--- a/inst/UnitTests/multiple_cons_test.R
+++ b/inst/UnitTests/multiple_cons_test.R
@@ -115,6 +115,11 @@ testSchemaChangeDuringWriteTable <- function() {
 
 testTemporaryTables <- function() {
   dbGetQuery(DATA$db1, "create temporary table tabletemp (a text)")
-  checkTrue("tabletemp" %in% dbListTables(DATA$db1))
+  checkTrue("tabletemp" %in% dbListTables(DATA$db1, temporary = TRUE))
+  checkEquals("tabletemp" %in% dbListTables(DATA$db1, temporary = FALSE), FALSE)
+  checkEquals("tabletemp" %in% dbListTables(DATA$db1), FALSE)
+
+  checkEquals("tabletemp" %in% dbListTables(DATA$db2, temporary = TRUE), FALSE)
+  checkEquals("tabletemp" %in% dbListTables(DATA$db2, temporary = FALSE), FALSE)
   checkEquals("tabletemp" %in% dbListTables(DATA$db2), FALSE)
 }


### PR DESCRIPTION
The new logical argument 'temporary' was added to dbListTables and
dbWriteTable. It defaults to FALSE for both functions. When TRUE, temporary tables
are included in the result for dbListTables. For dbWriteTable, a
temporary table is created when TRUE.

NOTE: R CMD check reports doc warnings. I'm unclear how we go about updating the docs and would very much like to add a make target to build/Makefile so this can be done quickly.

ping @hadley 