### PR TITLE
tweaks to resource management

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -7,7 +7,7 @@
 using namespace Rcpp;
 
 // rsqlite_connect
-XPtr<SqliteConnectionWrapper> rsqlite_connect(std::string path, bool allow_ext, int flags, std::string vfs = "");
+XPtr<SqliteConnectionPtr> rsqlite_connect(std::string path, bool allow_ext, int flags, std::string vfs = "");
 RcppExport SEXP RSQLite_rsqlite_connect(SEXP pathSEXP, SEXP allow_extSEXP, SEXP flagsSEXP, SEXP vfsSEXP) {
 BEGIN_RCPP
     SEXP __sexp_result;
@@ -17,7 +17,7 @@ BEGIN_RCPP
         Rcpp::traits::input_parameter< bool >::type allow_ext(allow_extSEXP );
         Rcpp::traits::input_parameter< int >::type flags(flagsSEXP );
         Rcpp::traits::input_parameter< std::string >::type vfs(vfsSEXP );
-        XPtr<SqliteConnectionWrapper> __result = rsqlite_connect(path, allow_ext, flags, vfs);
+        XPtr<SqliteConnectionPtr> __result = rsqlite_connect(path, allow_ext, flags, vfs);
         PROTECT(__sexp_result = Rcpp::wrap(__result));
     }
     UNPROTECT(1);
@@ -25,25 +25,25 @@ BEGIN_RCPP
 END_RCPP
 }
 // rsqlite_disconnect
-void rsqlite_disconnect(XPtr<SqliteConnectionWrapper> con);
+void rsqlite_disconnect(XPtr<SqliteConnectionPtr> con);
 RcppExport SEXP RSQLite_rsqlite_disconnect(SEXP conSEXP) {
 BEGIN_RCPP
     {
         Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< XPtr<SqliteConnectionWrapper> >::type con(conSEXP );
+        Rcpp::traits::input_parameter< XPtr<SqliteConnectionPtr> >::type con(conSEXP );
         rsqlite_disconnect(con);
     }
     return R_NilValue;
 END_RCPP
 }
 // rsqlite_get_exception
-std::string rsqlite_get_exception(XPtr<SqliteConnectionWrapper> con);
+std::string rsqlite_get_exception(XPtr<SqliteConnectionPtr> con);
 RcppExport SEXP RSQLite_rsqlite_get_exception(SEXP conSEXP) {
 BEGIN_RCPP
     SEXP __sexp_result;
     {
         Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< XPtr<SqliteConnectionWrapper> >::type con(conSEXP );
+        Rcpp::traits::input_parameter< XPtr<SqliteConnectionPtr> >::type con(conSEXP );
         std::string __result = rsqlite_get_exception(con);
         PROTECT(__sexp_result = Rcpp::wrap(__result));
     }
@@ -52,26 +52,26 @@ BEGIN_RCPP
 END_RCPP
 }
 // rsqlite_copy_database
-void rsqlite_copy_database(XPtr<SqliteConnectionWrapper> from, XPtr<SqliteConnectionWrapper> to);
+void rsqlite_copy_database(XPtr<SqliteConnectionPtr> from, XPtr<SqliteConnectionPtr> to);
 RcppExport SEXP RSQLite_rsqlite_copy_database(SEXP fromSEXP, SEXP toSEXP) {
 BEGIN_RCPP
     {
         Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< XPtr<SqliteConnectionWrapper> >::type from(fromSEXP );
-        Rcpp::traits::input_parameter< XPtr<SqliteConnectionWrapper> >::type to(toSEXP );
+        Rcpp::traits::input_parameter< XPtr<SqliteConnectionPtr> >::type from(fromSEXP );
+        Rcpp::traits::input_parameter< XPtr<SqliteConnectionPtr> >::type to(toSEXP );
         rsqlite_copy_database(from, to);
     }
     return R_NilValue;
 END_RCPP
 }
 // rsqlite_connection_valid
-bool rsqlite_connection_valid(XPtr<SqliteConnectionWrapper> con);
+bool rsqlite_connection_valid(XPtr<SqliteConnectionPtr> con);
 RcppExport SEXP RSQLite_rsqlite_connection_valid(SEXP conSEXP) {
 BEGIN_RCPP
     SEXP __sexp_result;
     {
         Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< XPtr<SqliteConnectionWrapper> >::type con(conSEXP );
+        Rcpp::traits::input_parameter< XPtr<SqliteConnectionPtr> >::type con(conSEXP );
         bool __result = rsqlite_connection_valid(con);
         PROTECT(__sexp_result = Rcpp::wrap(__result));
     }
@@ -80,13 +80,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // rsqlite_send_query
-XPtr<SqliteResult> rsqlite_send_query(XPtr<SqliteConnectionWrapper> con, std::string sql);
+XPtr<SqliteResult> rsqlite_send_query(XPtr<SqliteConnectionPtr> con, std::string sql);
 RcppExport SEXP RSQLite_rsqlite_send_query(SEXP conSEXP, SEXP sqlSEXP) {
 BEGIN_RCPP
     SEXP __sexp_result;
     {
         Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< XPtr<SqliteConnectionWrapper> >::type con(conSEXP );
+        Rcpp::traits::input_parameter< XPtr<SqliteConnectionPtr> >::type con(conSEXP );
         Rcpp::traits::input_parameter< std::string >::type sql(sqlSEXP );
         XPtr<SqliteResult> __result = rsqlite_send_query(con, sql);
         PROTECT(__sexp_result = Rcpp::wrap(__result));

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -3,38 +3,42 @@
 using namespace Rcpp;
 
 // [[Rcpp::export]]
-XPtr<SqliteConnectionWrapper> rsqlite_connect(std::string path, bool allow_ext, 
-                                       int flags, std::string vfs = "") {
-  SqliteConnectionWrapper* conn = new SqliteConnectionWrapper(path, allow_ext, flags, vfs);
-  return XPtr<SqliteConnectionWrapper>(conn, true);
+XPtr<SqliteConnectionPtr> rsqlite_connect(std::string path, bool allow_ext, 
+                                          int flags, std::string vfs = "") {
+  
+  SqliteConnectionPtr* pConn = new SqliteConnectionPtr(
+    new SqliteConnectionWrapper(path, allow_ext, flags, vfs)
+  );
+  
+  return XPtr<SqliteConnectionPtr>(pConn, true);
 }
 
 // [[Rcpp::export]]
-void rsqlite_disconnect(XPtr<SqliteConnectionWrapper> con) {
+void rsqlite_disconnect(XPtr<SqliteConnectionPtr> con) {
   if (R_ExternalPtrAddr(con) == NULL) stop("Connection already closed");
   
-  delete (SqliteConnectionWrapper*) con;
+  delete con.operator->();
   R_ClearExternalPtr(con);
 }
 
 // [[Rcpp::export]]
-std::string rsqlite_get_exception(XPtr<SqliteConnectionWrapper> con) {
+std::string rsqlite_get_exception(XPtr<SqliteConnectionPtr> con) {
   if (R_ExternalPtrAddr(con) == NULL) stop("Connection already closed");
   
-  return con->pConn->getException();
+  return (*con)->getException();
 }
 
 // [[Rcpp::export]]
-void rsqlite_copy_database(XPtr<SqliteConnectionWrapper> from, 
-                           XPtr<SqliteConnectionWrapper> to) {
+void rsqlite_copy_database(XPtr<SqliteConnectionPtr> from, 
+                           XPtr<SqliteConnectionPtr> to) {
   if (R_ExternalPtrAddr(from) == NULL) stop("From connection expired");
   if (R_ExternalPtrAddr(to) == NULL) stop("To connection expired");
   
-  from->pConn->copy_to(to->pConn);
+  (*from)->copy_to((*to));
 }
 
 // [[Rcpp::export]]
-bool rsqlite_connection_valid(XPtr<SqliteConnectionWrapper> con) {
+bool rsqlite_connection_valid(XPtr<SqliteConnectionPtr> con) {
   return R_ExternalPtrAddr(con) != NULL;
 }
 

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -3,10 +3,10 @@
 using namespace Rcpp;
 
 // [[Rcpp::export]]
-XPtr<SqliteResult> rsqlite_send_query(XPtr<SqliteConnectionWrapper> con, std::string sql) {
+XPtr<SqliteResult> rsqlite_send_query(XPtr<SqliteConnectionPtr> con, std::string sql) {
   if (R_ExternalPtrAddr(con) == NULL) stop("Connection expired");
 
-  SqliteResult* res = new SqliteResult(con->pConn, sql);
+  SqliteResult* res = new SqliteResult((*con), sql);
   return XPtr<SqliteResult>(res, true);
 }
 


### PR DESCRIPTION
- eliminate one layer of pointer wrapping
- use member access to connection rather than friendship
- use boost::noncopyable to prevent copying
- initialize all members of SqliteResult on construction
- check for NULL pConn_ before calling sqlite3_errmsg
