### PR TITLE
Remove XPtr boilerplate code

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -15,36 +15,29 @@ XPtr<SqliteConnectionPtr> rsqlite_connect(std::string path, bool allow_ext,
 
 // [[Rcpp::export]]
 void rsqlite_disconnect(XPtr<SqliteConnectionPtr> con) {
-  if (R_ExternalPtrAddr(con) == NULL) stop("Connection already closed");
-  
+
   int n = con->use_count();
   if (n > 1) {
     Rcout << "There are " << n - 1 << " result objects in use.\n" <<
       "The connection will be automatically released when they are closed\n";
   } 
   
-  delete con.operator->();
-  R_ClearExternalPtr(con);
+  con.release();
 }
 
 // [[Rcpp::export]]
 std::string rsqlite_get_exception(XPtr<SqliteConnectionPtr> con) {
-  if (R_ExternalPtrAddr(con) == NULL) stop("Connection already closed");
-  
   return (*con)->getException();
 }
 
 // [[Rcpp::export]]
 void rsqlite_copy_database(XPtr<SqliteConnectionPtr> from, 
                            XPtr<SqliteConnectionPtr> to) {
-  if (R_ExternalPtrAddr(from) == NULL) stop("From connection expired");
-  if (R_ExternalPtrAddr(to) == NULL) stop("To connection expired");
-  
   (*from)->copy_to((*to));
 }
 
 // [[Rcpp::export]]
 bool rsqlite_connection_valid(XPtr<SqliteConnectionPtr> con) {
-  return R_ExternalPtrAddr(con) != NULL;
+  return con;
 }
 

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -4,24 +4,17 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 XPtr<SqliteResult> rsqlite_send_query(XPtr<SqliteConnectionPtr> con, std::string sql) {
-  if (R_ExternalPtrAddr(con) == NULL) stop("Connection expired");
-
   SqliteResult* res = new SqliteResult((*con), sql);
   return XPtr<SqliteResult>(res, true);
 }
 
 // [[Rcpp::export]]
 void rsqlite_clear_result(XPtr<SqliteResult> res) {
-  if (R_ExternalPtrAddr(res) == NULL) stop("Results already closed");
-  
-  delete (SqliteResult*) res;
-  R_ClearExternalPtr(res);
+  res.release();
 }
 
 // [[Rcpp::export]]
 List rsqlite_fetch(XPtr<SqliteResult> res, int n = 10) {
-  if (R_ExternalPtrAddr(res) == NULL) stop("Results expired");
-  
   if (n < 0) {
     return res->fetch_all();  
   } else {
@@ -31,41 +24,31 @@ List rsqlite_fetch(XPtr<SqliteResult> res, int n = 10) {
 
 // [[Rcpp::export]]
 void rsqlite_bind_params(XPtr<SqliteResult> res, List params) {
-  if (R_ExternalPtrAddr(res) == NULL) stop("Results expired");
-  
   res->bind(params);
 }
 
 
 // [[Rcpp::export]]
 bool rsqlite_has_completed(XPtr<SqliteResult> res) {
-  if (R_ExternalPtrAddr(res) == NULL) stop("Results expired");
-  
   return res->complete();
 }
 
 // [[Rcpp::export]]
 int rsqlite_row_count(XPtr<SqliteResult> res) {
-  if (R_ExternalPtrAddr(res) == NULL) stop("Results expired");
-  
   return res->nrows() - 1;
 }
 
 // [[Rcpp::export]]
 int rsqlite_rows_affected(XPtr<SqliteResult> res) {
-  if (R_ExternalPtrAddr(res) == NULL) stop("Results closed");
-  
   return res->rows_affected();
 }
 
 // [[Rcpp::export]]
 List rsqlite_column_info(XPtr<SqliteResult> res) {
-  if (R_ExternalPtrAddr(res) == NULL) stop("Results expired");
-  
   return res->column_info();
 }
 
 // [[Rcpp::export]]
 bool rsqlite_result_valid(XPtr<SqliteResult> res) {
-  return R_ExternalPtrAddr(res) != NULL;
+  return res;
 }

--- a/tests/testthat/test-dbClearResult.R
+++ b/tests/testthat/test-dbClearResult.R
@@ -7,5 +7,5 @@ test_that("accessing cleared result throws error", {
   res <- dbSendQuery(con, "SELECT 1;")
   dbClearResult(res)
   
-  expect_error(dbFetch(res), "expired")
+  expect_error(dbFetch(res), "not valid")
 })

--- a/tests/testthat/test-dbConnect.R
+++ b/tests/testthat/test-dbConnect.R
@@ -21,32 +21,32 @@ test_that("can get and set vfs values", {
     windows = character(0),
     character(0)
   )
-  
+
   checkVfs <- function(v) {
     db <- dbConnect(SQLite(), vfs = v)
     on.exit(dbDisconnect(db))
     expect_equal(v, db@vfs)
-  }  
+  }
   for (v in allowed) checkVfs(v)
-}) 
+})
 
 test_that("forbidden operations throw errors", {
   tmpFile <- tempfile()
   on.exit(unlink(tmpFile))
-  
+
   ## error if file does not exist
   expect_error(dbConnect(SQLite(), tmpFile, flags = SQLITE_RO), "unable to open")
   expect_error(dbConnect(SQLite(), tmpFile, flags = SQLITE_RW), "unable to open")
-  
+
   dbrw <- dbConnect(SQLite(), tmpFile, flags = SQLITE_RWC)
   df <- data.frame(a=letters, b=runif(26L), stringsAsFactors=FALSE)
   expect_true(dbWriteTable(dbrw, "t1", df))
   dbDisconnect(dbrw)
-  
+
   dbro <- dbConnect(SQLite(), dbname = tmpFile, flags = SQLITE_RO)
   expect_error(dbWriteTable(dbro, "t2", df), "readonly database")
   dbDisconnect(dbro)
-  
+
   dbrw2 <- dbConnect(SQLite(), dbname = tmpFile, flags = SQLITE_RW)
   expect_true(dbWriteTable(dbrw2, "t2", df))
   dbDisconnect(dbrw2)
@@ -55,24 +55,24 @@ test_that("forbidden operations throw errors", {
 test_that("querying closed connection throws error", {
   db <- dbConnect(SQLite(), dbname = ":memory:")
   dbDisconnect(db)
-  expect_error(dbGetQuery(db, "select * from foo"), "expired")  
+  expect_error(dbGetQuery(db, "select * from foo"), "not valid")
 })
 
 test_that("can connect to same db from multiple connections", {
   dbfile <- tempfile()
-  con1 <- dbConnect(SQLite(), dbfile)  
+  con1 <- dbConnect(SQLite(), dbfile)
   con2 <- dbConnect(SQLite(), dbfile)
-  
+
   dbWriteTable(con1, "mtcars", mtcars)
   expect_equal(dbReadTable(con2, "mtcars"), mtcars)
 })
 
 test_that("temporary tables are connection local", {
   dbfile <- tempfile()
-  con1 <- dbConnect(SQLite(), dbfile)  
+  con1 <- dbConnect(SQLite(), dbfile)
   con2 <- dbConnect(SQLite(), dbfile)
 
   dbGetQuery(con1, "CREATE TEMPORARY TABLE temp (a TEXT)")
   expect_true(dbExistsTable(con1, "temp"))
-  expect_false(dbExistsTable(con2, "temp"))  
+  expect_false(dbExistsTable(con2, "temp"))
 })


### PR DESCRIPTION
Remove boilerplate checking code as these checks are now automatically performed by Rcpp.

Note this relies on code in a branch not yet merged into Rcpp: https://github.com/RcppCore/Rcpp/tree/feature/xptr-improvements