### PR TITLE
RSQlite master requires Rcpp master as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Or install the latest development version from github with:
 
 ```R
 # install.packages("devtools")
+devtools::install_github("RcppCore/Rcpp")
 devtools::install_github("rstats-db/DBI")
 devtools::install_github("rstats-db/SQL")
 devtools::install_github("rstats-db/RSQLite")


### PR DESCRIPTION
Description says it all. I wasn't able to install RSQlite without using Rcpp from master.