### PR TITLE
Add use covr and coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 install:
   - ./travis-tool.sh install_github rstats-db/DBI
   - ./travis-tool.sh install_github RcppCore/Rcpp
+  - ./travis-tool.sh install_github jimhester/covr
   - ./travis-tool.sh install_deps
   - R CMD INSTALL .
 
@@ -21,6 +22,9 @@ script: ./travis-tool.sh run_tests
 
 on_failure:
   - ./travis-tool.sh dump_logs
+
+on_success:
+  - Rscript -e "library(covr);coveralls(exclusions='src/sqlite3.c')"
 
 notifications:
   email:


### PR DESCRIPTION
This is a couple of months late and you are probably not going to be working on RSQLite again soon, but I finally have working full file exclusions in covr, so you can now use it with RSQLite.

Sorry for the delay, there were a number of back-end things which needed to be re-factored to get it working well.