### PR TITLE
Track dependencies for installing via R CMD INSTALL

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@ a.out.dSYM
 ^src/sqlite3/.*\.o$
 ^src/sqlite3/.*\.a$
 ^src/.*\.d$
+^src/Makevars\.local$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@ a.out.dSYM
 ^src-raw$
 ^src/sqlite3/.*\.o$
 ^src/sqlite3/.*\.a$
+^src/.*\.d$

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .Rproj.user
 .Rhistory
 src/*.so
+src/*.d
 src/**/*.o
 src/**/*.a
 config.status

--- a/src/Makevars
+++ b/src/Makevars
@@ -10,3 +10,9 @@ ${PKG_LIBS}:
 
 clean:
 	@(cd sqlite3 && $(MAKE) clean
+
+# This file exists only for R CMD INSTALL, is created as empty file
+# for building from source archive
+Makevars.local:
+	touch "$@"
+include Makevars.local

--- a/src/Makevars.local
+++ b/src/Makevars.local
@@ -1,0 +1,4 @@
+C_SOURCES = $(wildcard *.c)
+CXX_SOURCES = $(wildcard *.cpp)
+DEPFILES = ${C_SOURCES:.c=.d} ${CXX_SOURCES:.cpp=.d}
+include ${DEPFILES}


### PR DESCRIPTION
to force relevant recompile when only a header file changes, and there only for local installs (not from tarball).

I think this should be in *every* package that has native code.