### PR TITLE
Adding enabling of JSON1

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -3,6 +3,7 @@ PKG_CPPFLAGS=-DRSQLITE_USE_BUNDLED_SQLITE \
              -DSQLITE_ENABLE_FTS3 \
              -DSQLITE_ENABLE_FTS3_PARENTHESIS \
              -DSQLITE_ENABLE_FTS5 \
+             -DSQLITE_ENABLE_JSON1 \
              -DSQLITE_SOUNDEX
 
 PKG_LIBS = sqlite3/extension-functions.o sqlite3/sqlite3.o

--- a/tests/testthat/test-json.R
+++ b/tests/testthat/test-json.R
@@ -1,0 +1,10 @@
+context("dbJson")
+
+test_that("JSON types function", {
+  con <- dbConnect(SQLite())
+  gotJson <- dbGetQuery(con, 'SELECT json(\'{"this":"is","a":["test"]}\')')
+  expect_that(gotJson[1,], equals('{"this":"is","a":["test"]}'))
+
+  jsonArray <- dbGetQuery(con, 'SELECT json_array(1,2,3,4)')
+  expect_that(jsonArray[1,], equals('[1,2,3,4]'))
+})


### PR DESCRIPTION
This pull request enables SQLite's [JSON1](https://www.sqlite.org/json1.html) extension, and includes a basic test to assert that the new functions are available.