### PR TITLE
fledge: CRAN release v2.3.11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RSQLite
 Title: SQLite Interface for R
-Version: 2.3.10.9001
+Version: 2.3.11
 Date: 2025-05-04
 Authors@R: c(
     person("Kirill", "Müller", , "kirill@cynkra.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,21 +1,18 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RSQLite 2.3.10.9001 (2025-05-04)
+# RSQLite 2.3.11 (2025-05-04)
 
 ## Bug fixes
 
 - Compilation with `gcc` works again (#592, #594).
 
-## Continuous integration
-
-- Import from actions-sync, check carefully (#593).
-
-
-# RSQLite 2.3.10.9000 (2025-05-03)
-
 ## Features
 
 - Upgrade bundled SQLite to 3.49.1 (#590).
+
+## Continuous integration
+
+- Import from actions-sync, check carefully (#593).
 
 
 # RSQLite 2.3.10 (2025-05-02)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-RSQLite 2.3.10
+RSQLite 2.3.11
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-05-04, problems found: https://cran.r-project.org/web/checks/check_results_RSQLite.html
- [ ] other_issue: NA
See: <https://www.stats.ox.ac.uk/pub/bdr/memtests/gcc-UBSAN/RSQLite>
- [ ] other_issue: NA
See: <https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/RSQLite.out>

Check results at: https://cran.r-project.org/web/checks/check_results_RSQLite.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`