### PR TITLE
feat: Enable the percentile extension

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -6,6 +6,7 @@ PKG_CPPFLAGS=-Ivendor \
              -DSQLITE_ENABLE_FTS3_PARENTHESIS \
              -DSQLITE_ENABLE_FTS5 \
              -DSQLITE_ENABLE_JSON1 \
+             -DSQLITE_ENABLE_PERCENTILE \
              -DSQLITE_ENABLE_STAT4 \
              -DSQLITE_SOUNDEX \
              -DSQLITE_USE_URI=1 \

--- a/tests/testthat/test-percentile.R
+++ b/tests/testthat/test-percentile.R
@@ -1,0 +1,18 @@
+test_that("percentile extension", {
+  con <- dbConnect(SQLite(), ":memory:")
+  on.exit(dbDisconnect(con), add = TRUE)
+
+  dbWriteTable(con, "tbl", data.frame(x = 1:9))
+
+  ans1 <- dbGetQuery(con, "SELECT median(x) FROM tbl")
+  expect_equal(ans1[[1]], 5)
+
+  ans2 <- dbGetQuery(con, "SELECT percentile(x, 50) FROM tbl")
+  expect_equal(ans2[[1]], 5)
+
+  ans3 <- dbGetQuery(con, "SELECT percentile_cont(x, 0.5) FROM tbl")
+  expect_equal(ans3[[1]], 5)
+
+  ans4 <- dbGetQuery(con, "SELECT percentile_disc(x, 0.5) FROM tbl")
+  expect_equal(ans4[[1]], 5)
+})


### PR DESCRIPTION
This pull request enables the percentile extension (https://sqlite.org/percentile.html). A basic test is included to assert that the new functions are available.

The percentile extension provides four aggregate functions that compute a percentile score and/or the median value for a distribution. The extension is disabled by default and must be activated at compile-time using the -DSQLITE_ENABLE_PERCENTILE compile-time option. 
