### PR TITLE
fledge: CRAN release v2.4.8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RSQLite
 Title: SQLite Interface for R
-Version: 2.4.7.9006
+Version: 2.4.8
 Date: 2026-05-09
 Authors@R: c(
     person("Kirill", "Müller", , "kirill@cynkra.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,24 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RSQLite 2.4.7.9006 (2026-05-09)
+# RSQLite 2.4.8 (2026-05-09)
 
 ## Features
 
 - Upgrade bundled SQLite to 3.52.0 (#696).
+
+## Chore
+
+- Auto-update from GitHub Actions (#707).
+
+- Auto-update from GitHub Actions (#705).
+
+- Auto-update from GitHub Actions (#702).
+
+- Auto-update from GitHub Actions (#700).
+
+- Auto-update from GitHub Actions (#698).
+
+- Auto-update from GitHub Actions (#695).
 
 ## Continuous integration
 
@@ -16,45 +30,7 @@
 
 - Harmonize.
 
-
-# RSQLite 2.4.7.9005 (2026-05-04)
-
-## Chore
-
-- Auto-update from GitHub Actions (#707).
-
-
-# RSQLite 2.4.7.9004 (2026-03-22)
-
-## Chore
-
-- Auto-update from GitHub Actions (#705).
-
-
-# RSQLite 2.4.7.9003 (2026-03-14)
-
-## Chore
-
-- Auto-update from GitHub Actions (#702).
-
-
-# RSQLite 2.4.7.9002 (2026-03-13)
-
-## Chore
-
-- Auto-update from GitHub Actions (#700).
-
-- Auto-update from GitHub Actions (#698).
-
-
-# RSQLite 2.4.7.9001 (2026-03-08)
-
-## Chore
-
-- Auto-update from GitHub Actions (#695).
-
-
-# RSQLite 2.4.7.9000 (2026-02-27)
+## Uncategorized
 
 - Switching to development version.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,34 +6,6 @@
 
 - Upgrade bundled SQLite to 3.52.0 (#696).
 
-## Chore
-
-- Auto-update from GitHub Actions (#707).
-
-- Auto-update from GitHub Actions (#705).
-
-- Auto-update from GitHub Actions (#702).
-
-- Auto-update from GitHub Actions (#700).
-
-- Auto-update from GitHub Actions (#698).
-
-- Auto-update from GitHub Actions (#695).
-
-## Continuous integration
-
-- Cosmetics.
-
-- Bump action versions.
-
-- Align fledge workflow.
-
-- Harmonize.
-
-## Uncategorized
-
-- Switching to development version.
-
 
 # RSQLite 2.4.7 (2026-02-26)
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,6 +2,6 @@ RSQLite 2.4.8
 
 ## Cran Repository Policy
 
-- [ ] Reviewed CRP last edited 2026-04-21.
+- [x] Reviewed CRP last edited 2026-04-21.
 
 See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2026-02-20%7D...master@%7B2026-04-21%7D

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,7 @@
-RSQLite 2.4.7
+RSQLite 2.4.8
 
 ## Cran Repository Policy
 
-- [x] Reviewed CRP last edited 2026-02-20.
+- [ ] Reviewed CRP last edited 2026-04-21.
 
-See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2024-08-27%7D...master@%7B2026-02-20%7D
+See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2026-02-20%7D...master@%7B2026-04-21%7D


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2026-05-09, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`