### PR TITLE
fledge: CRAN release v3.52.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RSQLite
 Title: SQLite Interface for R
-Version: 3.51.99.9001
+Version: 3.52.0
 Date: 2026-05-09
 Authors@R: c(
     person("Kirill", "Müller", , "kirill@cynkra.com", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Authors@R: c(
   )
 Description: Embeds the SQLite database engine in R and provides an
     interface compliant with the DBI package. The source for the SQLite
-    engine (version 3.52.0) and for various extensions is included.
+    engine and for various extensions is included.
     System libraries will never be consulted because this package relies
     on static linking for the plugins it includes; this also ensures a
     consistent experience across all installations.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,29 +2,13 @@
 
 # RSQLite 3.52.0 (2026-05-09)
 
-## fledge
-
-- CRAN release v2.4.8 (#709).
-
-## Bug fixes
-
-- `dbListObjects()` returns empty instead of throwing an error if database not known.
-
 ## Features
 
-- Upgrade bundled SQLite to 3.52.0 (#696).
+- Upgrade bundled SQLite to 3.52.0 (#696), the package version is now aligned with the SQLite version.
 
 - Implement `dbListObjects()` for attached SQLite databases with schema prefix support (#689, #690).
 
 - Enable the percentile extension.
-
-## Chore
-
-- Deps.
-
-## Documentation
-
-- Align with SQLite version.
 
 
 # RSQLite 2.4.6 (2026-02-05)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,25 +1,14 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RSQLite 3.51.99.9001 (2026-05-09)
-
-## Bug fixes
-
-- `dbListObjects()` returns empty instead of throwing an error if database not known.
-
-## Chore
-
-- Deps.
-
-## Documentation
-
-- Align with SQLite version.
+# RSQLite 3.52.0 (2026-05-09)
 
 ## fledge
 
 - CRAN release v2.4.8 (#709).
 
+## Bug fixes
 
-# RSQLite 3.51.99.9000 (2026-05-09)
+- `dbListObjects()` returns empty instead of throwing an error if database not known.
 
 ## Features
 
@@ -28,6 +17,14 @@
 - Implement `dbListObjects()` for attached SQLite databases with schema prefix support (#689, #690).
 
 - Enable the percentile extension.
+
+## Chore
+
+- Deps.
+
+## Documentation
+
+- Align with SQLite version.
 
 
 # RSQLite 2.4.6 (2026-02-05)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,5 @@
-RSQLite 2.4.8
+RSQLite 3.52.0
 
 ## Cran Repository Policy
 
 - [x] Reviewed CRP last edited 2026-04-21.
-
-See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2026-02-20%7D...master@%7B2026-04-21%7D

--- a/data-raw/upgrade.R
+++ b/data-raw/upgrade.R
@@ -66,14 +66,10 @@ for (f in dir("patch", full.names = TRUE)) {
   stopifnot(system(paste0("patch -p1 -i ", f)) == 0)
 }
 
-version <- sub("^.*-([0-9])([0-9][0-9])(?:0([0-9])|([1-9][0-9]))[0-9]+[.].*$", "\\1.\\2.\\3\\4", latest_name)
-descr <- desc::desc_get_field("Description", trim_ws = FALSE)
-new_descr <- gsub("version [0-9]+\\.[0-9]+\\.[0-9]+", paste0("version ", version), descr)
-desc::desc_set(Description = new_descr)
+if (any(grepl("^src/", gert::git_status()$file))) {
+  gert::git_add("src")
 
-if (any(grepl("^src/|^DESCRIPTION", gert::git_status()$file))) {
-  gert::git_add(c("src", "DESCRIPTION"))
-
+  version <- sub("^.*-([0-9])([0-9][0-9])(?:0([0-9])|([1-9][0-9]))[0-9]+[.].*$", "\\1.\\2.\\3\\4", latest_name)
   commit_msg <- paste0("feat: Upgrade bundled SQLite to ", version)
   message("Commit message: ", commit_msg)
   gert::git_commit(commit_msg)


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2026-05-09, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`