### PR TITLE
fledge: CRAN release v3.53.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RSQLite
 Title: SQLite Interface for R
-Version: 3.52.0.9001
+Version: 3.53.0
 Date: 2026-05-16
 Authors@R: c(
     person("Kirill", "Müller", , "kirill@cynkra.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,10 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RSQLite 3.52.0.9001 (2026-05-16)
+# RSQLite 3.53.0 (2026-05-22)
 
-- Ci: Unify fledge.yaml across cynkratemplate and fledge (#86).
+## fledge
 
-
-# RSQLite 3.52.0.9000 (2026-05-13)
+- CRAN release v3.52.0 (#710).
 
 ## Features
 
@@ -29,9 +28,9 @@
 
 - Tweak fledge and ccache workflows.
 
-## fledge
+## Uncategorized
 
-- CRAN release v3.52.0 (#710).
+- Ci: Unify fledge.yaml across cynkratemplate and fledge (#86).
 
 
 # RSQLite 3.52.0 (2026-05-09)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,35 +2,9 @@
 
 # RSQLite 3.53.0 (2026-05-22)
 
-## fledge
-
-- CRAN release v3.52.0 (#710).
-
 ## Features
 
 - Upgrade bundled SQLite to 3.53.1 (#711).
-
-## Chore
-
-- Add ccache to `.gitignore` and `.Rbuildignore`.
-
-## Continuous integration
-
-- Create snapshot update PR against correct branch.
-
-- Add reference to `/apply-patch` workflow in commit message.
-
-- Clarify rationale for not deploying on schedule.
-
-- Only run fledge on pushes to main.
-
-- Prettier.
-
-- Tweak fledge and ccache workflows.
-
-## Uncategorized
-
-- Ci: Unify fledge.yaml across cynkratemplate and fledge (#86).
 
 
 # RSQLite 3.52.0 (2026-05-09)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-RSQLite 3.52.0
+RSQLite 3.53.0
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2026-05-22, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`