### PR TITLE
fledge: CRAN release v3.53.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RSQLite
 Title: SQLite Interface for R
-Version: 3.53.1.9008
+Version: 3.53.2
 Date: 2026-06-12
 Authors@R: c(
     person("Kirill", "Müller", , "kirill@cynkra.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,37 +2,18 @@
 
 # RSQLite 3.53.2 (2026-06-14)
 
-## fledge
-
-- CRAN release v3.53.0 (#724).
 
 ## Features
 
-- Optional HTTP/HTTPS VFS for read-only remote databases (@davidrsch, #680).
-
 - Upgrade bundled SQLite to 3.53.2 (#729).
 
-- Upgrade bundled SQLite to 3.53.2 (#727).
+- Optional HTTP/HTTPS VFS for read-only remote databases (@davidrsch, #680).
 
 ## Chore
 
 - Remove vendored object files from the source tarball via cleanup scripts (#736).
 
 - Rename `deps.mk` to `Makevars.deps` for `R CMD check` compatibility (#734).
-
-## Continuous integration
-
-- Update ccache-action reference.
-
-- Bump action version.
-
-## Documentation
-
-- Normalize `NEWS.md`.
-
-## Uncategorized
-
-- Merge branch 'cran-3.53.1'.
 
 
 # RSQLite 3.53.1 (2026-05-22)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,80 +1,38 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RSQLite 3.53.1.9008 (2026-06-12)
+# RSQLite 3.53.2 (2026-06-14)
+
+## fledge
+
+- CRAN release v3.53.0 (#724).
 
 ## Features
 
 - Optional HTTP/HTTPS VFS for read-only remote databases (@davidrsch, #680).
 
+- Upgrade bundled SQLite to 3.53.2 (#729).
 
-# RSQLite 3.53.1.9007 (2026-06-11)
-
-## Documentation
-
-- Normalize `NEWS.md`.
-
-
-# RSQLite 3.53.1.9006 (2026-06-10)
+- Upgrade bundled SQLite to 3.53.2 (#727).
 
 ## Chore
 
 - Remove vendored object files from the source tarball via cleanup scripts (#736).
 
-
-# RSQLite 3.53.1.9005 (2026-06-09)
-
-## Chore
-
 - Rename `deps.mk` to `Makevars.deps` for `R CMD check` compatibility (#734).
-
-
-# RSQLite 3.53.1.9004 (2026-06-08)
-
-## Features
-
-- Upgrade bundled SQLite to 3.53.2 (#729).
-
-- Upgrade bundled SQLite to 3.53.2 (#727).
 
 ## Continuous integration
 
 - Update ccache-action reference.
 
 - Bump action version.
+
+## Documentation
+
+- Normalize `NEWS.md`.
 
 ## Uncategorized
 
 - Merge branch 'cran-3.53.1'.
-
-
-# RSQLite 3.53.0.9003 (2026-06-06)
-
-## Features
-
-- Upgrade bundled SQLite to 3.53.2 (#729).
-
-
-# RSQLite 3.53.0.9002 (2026-06-05)
-
-## Features
-
-- Upgrade bundled SQLite to 3.53.2 (#727).
-
-
-# RSQLite 3.53.0.9001 (2026-05-24)
-
-## Continuous integration
-
-- Update ccache-action reference.
-
-- Bump action version.
-
-
-# RSQLite 3.53.0.9000 (2026-05-22)
-
-## fledge
-
-- CRAN release v3.53.0 (#724).
 
 
 # RSQLite 3.53.1 (2026-05-22)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,7 @@
-RSQLite 3.53.1
+RSQLite 3.53.2
 
 ## Cran Repository Policy
 
-- [x] Reviewed CRP last edited 2026-04-21.
+- [ ] Reviewed CRP last edited 2026-05-31.
+
+See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2026-04-21%7D...master@%7B2026-05-31%7D


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2026-06-08, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`