### PR TITLE
chore: Remove vendored object files from the source tarball via cleanup scripts

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Remove vendored build artifacts so they do not leak into the source tarball.
+#
+# src/vendor/sqlite3/sqlite3.o (listed in PKG_LIBS) and any *.a are excluded
+# via .Rbuildignore, but a vignette-triggered installation during R CMD build
+# recompiles them *after* the sources have been copied to the build directory.
+# R CMD build's own cleanup only removes top-level src/*.o, not files in the
+# vendored subdirectory, so without this script the object file ends up in the
+# tarball and R CMD check reports it ("checking if this is a source package").
+rm -f src/vendor/sqlite3/*.o src/vendor/sqlite3/*.a

--- a/cleanup.ucrt
+++ b/cleanup.ucrt
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Windows counterpart of 'cleanup': remove vendored build artifacts so they do
+# not leak into the source tarball. Run via `sh` by R CMD build / R CMD INSTALL.
+# See 'cleanup' for the full explanation.
+rm -f src/vendor/sqlite3/*.o src/vendor/sqlite3/*.a

--- a/cleanup.win
+++ b/cleanup.win
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Windows counterpart of 'cleanup': remove vendored build artifacts so they do
+# not leak into the source tarball. Run via `sh` by R CMD build / R CMD INSTALL.
+# See 'cleanup' for the full explanation.
+rm -f src/vendor/sqlite3/*.o src/vendor/sqlite3/*.a


### PR DESCRIPTION
## Problem
R CMD check on current R-devel reports:

```
checking if this is a source package ... NOTE
  Found the following apparent object files/libraries:
    src/vendor/sqlite3/sqlite3.o
  Object files/libraries should not be included in a source package.
```

This is the same class of regression as the `deps.mk` issue fixed in #734.

## Root cause
`src/vendor/sqlite3/sqlite3.o` (referenced via `PKG_LIBS`) is excluded by `.Rbuildignore`. Since the R CMD build cleanup rework (PR#17549), that exclusion is applied **before** the sources are copied into the temporary build directory. Building the vignettes then triggers a temporary **installation** in that directory, which recompiles the vendored object. R CMD build's final cleanup only removes top-level `src/*.o` (the shared `clean.mk` target is empty), **not** files in the vendored subdirectory — so the object ends up in the tarball.

## Fix
Add top-level `cleanup` scripts that remove the vendored build artifacts:

- `cleanup` — Unix (Linux/macOS)
- `cleanup.win`, `cleanup.ucrt` — Windows (legacy / UCRT toolchains)

```sh
rm -f src/vendor/sqlite3/*.o src/vendor/sqlite3/*.a
```

R CMD build runs the appropriate script **unconditionally** during its final cleanup — i.e. *after* the vignette-triggered installation — so the object no longer leaks. The scripts are also run by R CMD INSTALL **only** with `--clean`/`--preclean` (i.e. after linking), so a plain `R CMD INSTALL .` is unaffected. All three are committed executable (mode `100755`), which R CMD check requires for `cleanup`.

## Verification
On a stock R-devel build exhibiting the regression (no R-side fix), using a minimal package with the identical vendored-object layout (object in `PKG_LIBS`, excluded via `.Rbuildignore`, vignette present):

- **without** the script: `vendor/<obj>.o` leaks into the tarball (reproduces the NOTE)
- **with** the script: the object is absent

For RSQLite directly: `./cleanup` removes `src/vendor/sqlite3/*.o` and `*.a` (leaving `sqlite3.c`), and `R CMD build` completes with no cleanup errors.

## Note
The underlying R CMD build behaviour (regenerated `.Rbuildignore`d files leaking into the tarball) is arguably a bug in R itself; a complementary fix that re-applies `.Rbuildignore` before tarring has been prepared against R-devel. These `cleanup` scripts make RSQLite robust on stock R-devel regardless, and are a standard, portable mechanism.

https://claude.ai/code/session_01HhGLRG5AffBVtteMzhueoe

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhGLRG5AffBVtteMzhueoe)_