### PR TITLE
ci: infer compiler defaults for ccache across R version matrix

### DIFF
--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -147,11 +147,21 @@ runs:
     - name: Use ccache for compiling R code, and parallelize
       run: |
         mkdir -p ~/.R
-        echo 'CC      :=  ccache $(CC)' >> ~/.R/Makevars
-        echo 'CXX     :=  ccache $(CXX)' >> ~/.R/Makevars
-        echo 'CXX11   :=  ccache $(CXX11)' >> ~/.R/Makevars
-        echo 'CXX14   :=  ccache $(CXX14)' >> ~/.R/Makevars
-        echo 'CXX17   :=  ccache $(CXX17)' >> ~/.R/Makevars
+        # Infer each compiler default for the active R version from R CMD config,
+        # then prepend ccache. Reading the resolved defaults preserves the
+        # standard flags R selects per version (e.g. -std=gnu2x for C, -std=gnu++17
+        # / -std=gnu++20 for C++); a plain "CC = ccache gcc" override would drop
+        # them and silently downgrade the standard across the version matrix.
+        # Inference uses an empty user Makevars so we always read the pristine
+        # Makeconf defaults, never a value we just wrote.
+        empty_makevars="$(mktemp)"
+        for var in CC CXX CXX11 CXX14 CXX17 CXX20 CXX23; do
+          val="$(R_MAKEVARS_USER="$empty_makevars" R CMD config "$var" 2>/dev/null || true)"
+          if [ -n "$val" ]; then
+            echo "$var = ccache $val" >> ~/.R/Makevars
+          fi
+        done
+        rm -f "$empty_makevars"
         echo 'MAKEFLAGS = -j2' >> ~/.R/Makevars
         cat ~/.R/Makevars
 

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -154,6 +154,11 @@ runs:
         # them and silently downgrade the standard across the version matrix.
         # Inference uses an empty user Makevars so we always read the pristine
         # Makeconf defaults, never a value we just wrote.
+        # Note: the versioned switches (CXX11..CXX23) intentionally come out as
+        # bare "g++" with no -std flag. R keeps the standard in a separate
+        # CXXnnSTD variable (CXX17STD = -std=gnu++17, ...) and applies it on top
+        # at compile time, so wrapping only CXXnn with ccache is correct and we
+        # must NOT pin -std here ourselves.
         empty_makevars="$(mktemp)"
         for var in CC CXX CXX11 CXX14 CXX17 CXX20 CXX23; do
           val="$(R_MAKEVARS_USER="$empty_makevars" R CMD config "$var" 2>/dev/null || true)"

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -168,7 +168,9 @@ runs:
         done
         rm -f "$empty_makevars"
         echo 'MAKEFLAGS = -j2' >> ~/.R/Makevars
+        echo "===== generated ~/.R/Makevars ====="
         cat ~/.R/Makevars
+        echo "==================================="
 
         echo 'CCACHE_SLOPPINESS=locale,time_macros' | tee -a $GITHUB_ENV
 


### PR DESCRIPTION
## Summary

The ccache setup in `.github/workflows/install/action.yml` wrapped the compilers using the recursive make trick `CC := ccache $(CC)`. This PR switches to **inferring each compiler's resolved default from `R CMD config` and prepending `ccache`**, which is more robust across the R version check matrix (`devel` + latest releases).

## Why

`R CMD config CC`/`CXX` report the fully resolved default for whichever R version is active, *including the language-standard flag R selects for that version*:

| R version | C default | C++ default |
|-----------|-----------|-------------|
| 4.4.x     | C17       | C++17       |
| 4.5.x     | C23 (`-std=gnu2x`) | C++17 (`-std=gnu++17`) |
| 4.6.0+    | C23       | C++20 (`-std=gnu++20`) |

By reading these resolved values and prepending `ccache`, every matrix entry keeps building with its own default standard. A plain override like `CC = ccache gcc` would drop the `-std=` flag and silently fall back to the bare compiler default (e.g. gcc 13's `gnu17`), downgrading the C standard.

## Details

- Defaults are inferred with an **empty user Makevars** (`R_MAKEVARS_USER`), so inference always reads the pristine `Makeconf` defaults and never a value written earlier in the loop.
- **Empty results are skipped**, so the loop stays correct on R versions that drop `CXX11`/`CXX14`.
- `CXX20`/`CXX23` are now covered by ccache too (previously only `CXX11`/`CXX14`/`CXX17`).

### Generated `~/.R/Makevars` (verified locally on R 4.5.3)

```make
CC = ccache gcc -std=gnu2x
CXX = ccache g++ -std=gnu++17
CXX11 = ccache g++
CXX14 = ccache g++
CXX17 = ccache g++
CXX20 = ccache g++
CXX23 = ccache g++
MAKEFLAGS = -j2
```

RSQLite does not pin a C++ standard, so it relies on R's per-version default — exactly what this preserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Uf5VX6NsEvFMppR6a3fjx)_