### PR TITLE
ci: add RHEL 8 (old gcc) lane that rejects C23 code

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -321,6 +321,7 @@ jobs:
           needs: build, check
           lang: ${{ matrix.lang }}
           std: ${{ matrix.std }}
+          flags: ${{ matrix.flags }}
 
       - uses: ./.github/workflows/custom/after-install
         if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: "Compile-only standard jobs: the -std value to pin, e.g. gnu90 or gnu++23 (empty = use R's defaults)"
     required: false
     default: ""
+  flags:
+    description: "Compile-only standard jobs: extra compiler flags appended after -std, e.g. -Werror=c11-c2x-compat"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -178,18 +182,20 @@ runs:
             echo "$var = ccache $val" >> ~/.R/Makevars
           fi
         done
-        # Compile-only standard jobs pin a non-default C/C++ standard. Reuse the
-        # same base-compiler inference as the loop above (so there is no second
-        # copy of the Makevars logic) and append an override: a later assignment
-        # wins in make, so this swaps the standard while keeping the ccache
-        # wrapper. With no std requested this is a no-op and R's defaults stand.
+        # Compile-only standard jobs pin a non-default C/C++ standard (and may
+        # add extra flags, e.g. -Werror=c11-c2x-compat to reject C23 code the
+        # way an old gcc would). Reuse the same base-compiler inference as the
+        # loop above (so there is no second copy of the Makevars logic) and
+        # append an override: a later assignment wins in make, so this swaps the
+        # standard while keeping the ccache wrapper. With no std requested this
+        # is a no-op and R's defaults stand.
         if [ -n "${{ inputs.std }}" ]; then
           if [ "${{ inputs.lang }}" = "cxx" ]; then
             std_base="$(R_MAKEVARS_USER="$empty_makevars" R CMD config CXX | awk '{print $1}')"
-            echo "CXX = ccache $std_base -std=${{ inputs.std }}" >> ~/.R/Makevars
+            echo "CXX = ccache $std_base -std=${{ inputs.std }} ${{ inputs.flags }}" >> ~/.R/Makevars
           else
             std_base="$(R_MAKEVARS_USER="$empty_makevars" R CMD config CC | awk '{print $1}')"
-            echo "CC = ccache $std_base -std=${{ inputs.std }}" >> ~/.R/Makevars
+            echo "CC = ccache $std_base -std=${{ inputs.std }} ${{ inputs.flags }}" >> ~/.R/Makevars
           fi
         fi
         rm -f "$empty_makevars"

--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -33,14 +33,21 @@ covr <- data.frame(os = "ubuntu-24.04", r = r_versions[2], covr = "true", desc =
 #
 # Maintaining these as standards evolve:
 #   * `c_stds` / `cxx_stds` below list the standards to compile under, as
-#     (human label, `-std` value). Use the GNU dialect ("gnu*") so they match
-#     the standards R itself uses, not strict ISO ("c*").
-#   * When compilers gain a newer standard, add it here, e.g. append
-#     list("C++26", "gnu++26") to `cxx_stds`, or list("C23", "gnu2x") /
-#     list("C2Y", "gnu2y") to `c_stds`. Keep `c_stds` ordered oldest-first and
-#     keep each entry's `year` accurate (it is compared against the C floor
-#     below). Drop a standard once it is no longer worth testing (e.g. once it
-#     becomes R's default and is covered by the regular check jobs).
+#     (human label, `-std` value, extra `flags`). Use the GNU dialect ("gnu*")
+#     so they match the standards R itself uses, not strict ISO ("c*").
+#   * When compilers gain a newer standard, add a row, e.g. C++26 as
+#     ("C++26", "gnu++26", "") to `cxx_stds`, or C23 as ("C23", "gnu2x", "") to
+#     `c_stds`. Keep `c_stds` ordered oldest-first and keep each `year` accurate
+#     (it is compared against the C floor below). Drop a standard once it is no
+#     longer worth testing (e.g. once it becomes R's default and is covered by
+#     the regular check jobs).
+#   * `flags` carries extra compiler flags for an entry. It is used to replicate
+#     an old toolchain on a modern compiler without installing it: the "C11
+#     (RHEL 8 gcc 8)" entry pins gnu11 (gcc 8's default) and turns the C11->C23
+#     compatibility warnings into errors (-Werror=c11-c2x-compat), so a modern
+#     gcc rejects C23-only constructs the way RHEL 8's gcc does, instead of
+#     silently accepting them as extensions. (gcc 14+ spells the flag
+#     -Wc11-c23-compat; the c2x alias still works.)
 #   * The C entries honor a C-standard floor declared in DESCRIPTION's
 #     SystemRequirements: any standard older than the declared minimum is
 #     dropped, since the package does not claim to support it. To change which
@@ -55,17 +62,19 @@ native_sources <- if (dir.exists("src")) {
 has_c_sources <- any(grepl("[.]c$", native_sources))
 has_cxx_sources <- any(grepl("[.](cc|cpp|cxx)$", native_sources))
 
-# Older C standards to compile under, oldest first. `year` is used only to
-# compare against the SystemRequirements floor.
+# C standards to compile under, oldest first. `year` is compared against the
+# SystemRequirements floor; `flags` adds any extra compiler flags (see above).
 c_stds <- data.frame(
-  label = c("C90", "C99", "C17"),
-  std = c("gnu90", "gnu99", "gnu17"),
-  year = c(1990, 1999, 2017)
+  label = c("C90", "C99", "C11 (RHEL 8 gcc 8)", "C17"),
+  std = c("gnu90", "gnu99", "gnu11", "gnu17"),
+  flags = c("", "", "-Werror=c11-c2x-compat", ""),
+  year = c(1990, 1999, 2011, 2017)
 )
-# Newest C++ standard to compile under.
+# Newest C++ standard to compile under (columns parallel c_stds).
 cxx_stds <- data.frame(
   label = "C++23",
-  std = "gnu++23"
+  std = "gnu++23",
+  flags = ""
 )
 
 # Honor a C-standard floor from SystemRequirements and drop the C standards the
@@ -93,6 +102,7 @@ if (has_c_sources && nrow(c_stds) > 0) {
   std_list <- c(std_list, list(data.frame(
     os = "ubuntu-24.04", r = std_r, lang = "c",
     std = c_stds$std,
+    flags = c_stds$flags,
     desc = paste0("compile-only ", c_stds$label)
   )))
 }
@@ -100,6 +110,7 @@ if (has_cxx_sources && nrow(cxx_stds) > 0) {
   std_list <- c(std_list, list(data.frame(
     os = "ubuntu-24.04", r = std_r, lang = "cxx",
     std = cxx_stds$std,
+    flags = cxx_stds$flags,
     desc = paste0("compile-only ", cxx_stds$label)
   )))
 }


### PR DESCRIPTION
Follow-up to #751 (now merged). Adds a compile-only matrix lane that replicates **RHEL 8's system gcc 8** — which defaults to C11 and cannot compile C23 — on a modern compiler, **without installing an old toolchain**.

## The problem

RSQLite's bundled HTTP VFS extension (`vendor/extensions/http.c`) defines functions with **unnamed parameters** (`static int httpWrite(sqlite3_file*, const void*, int, sqlite3_int64){…}`), which is **C23-only** syntax. RHEL 8's gcc 8 rejects it, but the existing `gnu17` matrix lane stays green because **modern gcc accepts C23 constructs as silent extensions even under an old `-std`**.

## The fix

A new `compile-only C11 (RHEL 8 gcc 8)` entry that pins `-std=gnu11` (gcc 8's C default) and promotes the C11→C23 compatibility warnings to errors:

```
-std=gnu11 -Werror=c11-c2x-compat
```

`-Wc11-c2x-compat` is surgical — it flags **only** constructs valid in C23 but not C11, so a modern gcc rejects exactly what RHEL 8 does. It avoids the false positives of `-pedantic-errors` (which would also reject GNU extensions RHEL 8 accepts, plus vendored-code nits). Verified locally: the lane fails with **all errors confined to `http.c`** — the SQLite amalgamation is untouched.

(gcc 14+ spells the flag `-Wc11-c23-compat`; the `c2x` alias still works.)

## Mechanism

- The `c_stds` / `cxx_stds` tables in `versions-matrix/action.R` gain a **`flags`** column for per-entry extra compiler flags.
- The `install` action gains a matching **`flags`** input, appended after `-std` in the generated Makevars (reusing the existing centralized override logic — no duplication).
- `rcc-full` passes `matrix.flags` through.

## ⚠️ Expected red until a follow-up

Like the C90 lane, this entry is **red until `vendor/extensions/http.c` is fixed** (name the parameters) in its dedicated PR. That's the agreed accept-red-until-fixed arrangement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Uf5VX6NsEvFMppR6a3fjx)_