### PR TITLE
ci: also reject C23 constructs on the C17 lane

### DIFF
--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -41,13 +41,21 @@ covr <- data.frame(os = "ubuntu-24.04", r = r_versions[2], covr = "true", desc =
 #     (it is compared against the C floor below). Drop a standard once it is no
 #     longer worth testing (e.g. once it becomes R's default and is covered by
 #     the regular check jobs).
-#   * `flags` carries extra compiler flags for an entry. It is used to replicate
-#     an old toolchain on a modern compiler without installing it: the "C11
-#     (RHEL 8 gcc 8)" entry pins gnu11 (gcc 8's default) and turns the C11->C23
-#     compatibility warnings into errors (-Werror=c11-c2x-compat), so a modern
-#     gcc rejects C23-only constructs the way RHEL 8's gcc does, instead of
-#     silently accepting them as extensions. (gcc 14+ spells the flag
-#     -Wc11-c23-compat; the c2x alias still works.)
+#   * `flags` carries extra compiler flags for an entry. It is used to forbid
+#     constructs newer than the targeted standard, which a modern gcc otherwise
+#     accepts as silent extensions: -Werror=c11-c2x-compat makes gcc reject
+#     C23-only constructs. Two entries carry it, for distinct reasons:
+#       - "C11 (RHEL 8 gcc 8)" is platform-motivated: gnu11 is gcc 8's default,
+#         so this reproduces what RHEL 8 actually does. It tracks one distro's
+#         compiler and may be rebased or retired as platforms move on.
+#       - "C17" is standard-motivated and platform-agnostic: it states that the
+#         package's C compiles as C17 without relying on C23 features, a durable
+#         portability contract independent of any single toolchain (C17 is R's
+#         default on 4.4 and the floor of most current toolchains). C17 added no
+#         features over C11, so today it catches the same code as the RHEL 8
+#         lane; keeping it independent means the C23 guard survives if the RHEL 8
+#         entry is ever changed.
+#     (gcc 14+ spells the flag -Wc11-c23-compat; the c2x alias still works.)
 #   * The C entries honor a C-standard floor declared in DESCRIPTION's
 #     SystemRequirements: any standard older than the declared minimum is
 #     dropped, since the package does not claim to support it. To change which
@@ -67,7 +75,7 @@ has_cxx_sources <- any(grepl("[.](cc|cpp|cxx)$", native_sources))
 c_stds <- data.frame(
   label = c("C90", "C99", "C11 (RHEL 8 gcc 8)", "C17"),
   std = c("gnu90", "gnu99", "gnu11", "gnu17"),
-  flags = c("", "", "-Werror=c11-c2x-compat", ""),
+  flags = c("", "", "-Werror=c11-c2x-compat", "-Werror=c11-c2x-compat"),
   year = c(1990, 1999, 2011, 2017)
 )
 # Newest C++ standard to compile under (columns parallel c_stds).


### PR DESCRIPTION
Follow-up to #752 (now merged). Adds `-Werror=c11-c2x-compat` to the **C17** compile-only lane as well, so it rejects C23-only constructs just like the C11 / RHEL 8 lane. One-line change to the `flags` column, rebased onto current main.

## The case (it *is* redundant today — here's why it's still worth it)

C17 added no language features over C11, so the C17 lane catches exactly the same C23 constructs as the RHEL 8 / C11 lane right now. The justification is **intent and lifecycle**, not catching different bugs:

| Lane | Motivation | Lifecycle |
|---|---|---|
| `C11 (RHEL 8 gcc 8)` | **Platform** — gnu11 is gcc 8's default, reproduces what RHEL 8 actually does | Tracks one distro's compiler; may be rebased/retired as platforms move (RHEL 8 EOL, RHEL 9 = gcc 11/C17, …) |
| `C17` | **Standard** — a platform-agnostic contract: "RSQLite's C compiles as C17 with no reliance on C23 features" | Durable; C17 is R's default on 4.4 and the floor of most current toolchains |

Keeping the C23 guard on the standard-defined C17 lane means the protection **survives if the RHEL 8 entry is later changed or removed** — the two lanes answer different questions and have independent lifecycles even though they agree today.

**Cost (honest):** a second CI job that currently always agrees with the RHEL 8 lane, and — like that lane — it's **red until `vendor/extensions/http.c` is fixed** in its separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Uf5VX6NsEvFMppR6a3fjx)_