### PR TITLE
ci: restore the C90 lane and regroup C standards by R release

### DIFF
--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -53,8 +53,8 @@ covr <- data.frame(os = "ubuntu-24.04", r = r_versions[2], covr = "true", desc =
 #   * The C entries honor a C-standard floor declared in DESCRIPTION's
 #     SystemRequirements: any standard older than the declared minimum is
 #     dropped, since the package does not claim to support it. To change which
-#     C standards are tested, edit SystemRequirements (e.g. add "USE_C11" to
-#     stop testing C99), not this file. There is no analogous C++ gate; add one
+#     C standards are tested, edit SystemRequirements (e.g. add "USE_C99" to
+#     stop testing C90), not this file. There is no analogous C++ gate; add one
 #     the same way if you start honoring a declared "C++NN" minimum.
 native_sources <- if (dir.exists("src")) {
   list.files("src", pattern = "[.](c|cc|cpp|cxx)$", recursive = TRUE)
@@ -68,11 +68,11 @@ has_cxx_sources <- any(grepl("[.](cc|cpp|cxx)$", native_sources))
 # release. `year` is compared against the SystemRequirements floor; `flags`
 # adds any extra compiler flags (see above).
 c_stds <- data.frame(
-  label = c("C99", "C11", "C17"),
-  std = c("gnu99", "gnu11", "gnu17"),
-  r = c("oldrel-4", "oldrel-3", "oldrel-2"),
-  flags = c("", "-Werror=c11-c2x-compat", "-Werror=c11-c2x-compat"),
-  year = c(1999, 2011, 2017)
+  label = c("C90", "C99", "C11", "C17"),
+  std = c("gnu90", "gnu99", "gnu11", "gnu17"),
+  r = c("oldrel-4", "oldrel-3", "oldrel-2", "oldrel-2"),
+  flags = c("", "", "-Werror=c11-c2x-compat", "-Werror=c11-c2x-compat"),
+  year = c(1990, 1999, 2011, 2017)
 )
 # Newest C++ standard to compile under (columns parallel c_stds).
 cxx_stds <- data.frame(


### PR DESCRIPTION
Restores the C90 compile-only lane (dropped in #755) and regroups the standard-to-release pairing so the two C1x lanes share a release.

## Resulting C lanes

| Lane | `-std` | R release | extra flags |
|---|---|---|---|
| C90 | `gnu90` | **oldrel-4** | — |
| C99 | `gnu99` | **oldrel-3** | — |
| C11 | `gnu11` | **oldrel-2** | `-Werror=c11-c2x-compat` |
| C17 | `gnu17` | **oldrel-2** | `-Werror=c11-c2x-compat` |
| C++23 | `gnu++23` | newest release | — |

- Brings **C90** back.
- C99 moves to oldrel-3; **both C1x lanes (C11, C17) run on oldrel-2**.
- C++23 stays on the newest release; C11/C17 keep `-Werror=c11-c2x-compat` (no C23 features).

One-file change to `c_stds` (plus the `SystemRequirements` comment example, since C90 is the lowest tested standard again).

## Note on red lanes

- **C90** is red until the bundled HTTP VFS extension's C99 for-loop declarations are fixed.
- **C11 / C17** are red until that same file's C23 unnamed parameters are fixed.

Both are in `vendor/extensions/http.c`, headed for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Uf5VX6NsEvFMppR6a3fjx)_