### PR TITLE
ci(covr): install xml2 from r-lib/xml2#479 to fix multi-hour coverage runs

### DIFF
--- a/.github/workflows/covr/action.yml
+++ b/.github/workflows/covr/action.yml
@@ -8,6 +8,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # covr::to_cobertura() builds the report by appending one XML node per
+    # covered source line. With released xml2, xml_add_child() re-scans all
+    # existing siblings on every append (O(n^2)), which makes coverage for
+    # packages with large sources (e.g. bundled sqlite3.c, ~67k lines) take
+    # hours. r-lib/xml2#479 makes the default append O(1). Install it here so
+    # the fast path is used only for coverage runs.
+    - name: Install xml2 with O(1) xml_add_child() (r-lib/xml2#479)
+      run: pak::pak("r-lib/xml2#479")
+      shell: Rscript {0}
+
     - name: Run coverage check
       run: |
         if (dir.exists("tests/testthat")) {


### PR DESCRIPTION
## Problem

The coverage job on GitHub Actions takes ~5 hours. The time is spent entirely **after** the last `Moving gcov outputs to covr directory.` message — i.e. in `covr::to_cobertura(cov)`, which the covr action runs after `package_coverage()`.

`to_cobertura()` builds the Cobertura report by appending one `<line>` XML node per covered source line. With released xml2, `xml_add_child()` defaults to `.where = length(xml_children(.x))`, which re-enumerates **all** existing siblings on every append → **O(n²)** per file. For RSQLite's bundled `sqlite3.c` (~67k covered lines under a single `<lines>` node) that is ~4.5 billion operations.

### Evidence

Profiling the real coverage object (74,017 entries; `sqlite3.c` = 67,619) showed everything up to and including `package_coverage()` finishing in ~1.2 min, while `to_cobertura()` dominated, with `Rprof` attributing **94%** of time to `xml_add_child` → `xml_children`/`xml_nodeset`.

## Fix

The root cause is in xml2 and is fixed upstream by **[r-lib/xml2#479](https://github.com/r-lib/xml2/pull/479)**, which makes the default append O(1).

This PR installs xml2 from that PR at the start of the covr action, so the fast path is used **only for coverage runs**:

```yaml
- name: Install xml2 with O(1) xml_add_child() (r-lib/xml2#479)
  run: pak::pak("r-lib/xml2#479")
  shell: Rscript {0}
```

`pak` is already provisioned by `setup-r-dependencies` in this job, so no extra setup is required.

### Verified

With xml2 installed from the PR, the **unmodified, released** `to_cobertura()` processes the full RSQLite coverage data in **~25 seconds** (down from ~5 hours).

> [!NOTE]
> This pins coverage to a PR build of xml2. Once r-lib/xml2#479 is merged and released, this step can be dropped (or switched to `r-lib/xml2` / the released version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh6ePmbJHgSzUoVMWk7q1s)_