### PR TITLE
docs: clarify remote SQLite connection entry points

### DIFF
--- a/R/dbConnect_SQLiteDriver.R
+++ b/R/dbConnect_SQLiteDriver.R
@@ -12,6 +12,11 @@
 #'     will be deleted when the connection is closed.
 #'   \item `":memory:"` or `"file::memory:"` will create a temporary
 #'     in-memory database.
+#'   \item If the optional HTTP VFS is available, remote read-only SQLite
+#'     databases can be opened with [sqliteRemote()] or with a SQLite URI
+#'     filename such as
+#'     `"file:https://example.org/db.sqlite?vfs=http&immutable=1"` and
+#'     `flags = SQLITE_RO`.
 #'   }
 #' @param cache_size Advanced option. A positive integer to change the maximum
 #'   number of disk pages that SQLite holds in memory (SQLite's default is

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,6 +43,30 @@ when the package is built with libcurl support, enabling read-only access to rem
 SQLite databases. See the help pages for `initExtension()`, `sqliteHttpConfig()`,
 `sqliteRemote()`, and `sqliteHasHttpVFS()`.
 
+If HTTP VFS support is available, `sqliteRemote()` is the easiest way to open a
+remote database:
+
+```r
+if (sqliteHasHttpVFS()) {
+  con <- sqliteRemote("https://example.org/db.sqlite")
+  dbDisconnect(con)
+}
+```
+
+For cases where you need the explicit SQLite URI filename, use
+`dbConnect()` with `flags = SQLITE_RO`:
+
+```r
+if (sqliteHasHttpVFS()) {
+  con <- dbConnect(
+    RSQLite::SQLite(),
+    "file:https://example.org/db.sqlite?vfs=http&immutable=1",
+    flags = SQLITE_RO
+  )
+  dbDisconnect(con)
+}
+```
+
 Discussions associated with DBI and related database packages take place on [R-SIG-DB](https://stat.ethz.ch/mailman/listinfo/r-sig-db).
 The website [Databases using R](https://db.rstudio.com/) describes the tools and best practices in this ecosystem.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,30 @@ read-only access to remote SQLite databases. See the help pages for
 `initExtension()`, `sqliteHttpConfig()`, `sqliteRemote()`, and
 `sqliteHasHttpVFS()`.
 
+If HTTP VFS support is available, `sqliteRemote()` is the easiest way to
+open a remote database:
+
+``` r
+if (sqliteHasHttpVFS()) {
+  con <- sqliteRemote("https://example.org/db.sqlite")
+  dbDisconnect(con)
+}
+```
+
+For cases where you need the explicit SQLite URI filename, use
+`dbConnect()` with `flags = SQLITE_RO`:
+
+``` r
+if (sqliteHasHttpVFS()) {
+  con <- dbConnect(
+    RSQLite::SQLite(),
+    "file:https://example.org/db.sqlite?vfs=http&immutable=1",
+    flags = SQLITE_RO
+  )
+  dbDisconnect(con)
+}
+```
+
 Discussions associated with DBI and related database packages take place
 on [R-SIG-DB](https://stat.ethz.ch/mailman/listinfo/r-sig-db). The
 website [Databases using R](https://db.rstudio.com/) describes the tools

--- a/man/SQLite.Rd
+++ b/man/SQLite.Rd
@@ -55,6 +55,11 @@ platform. There are two exceptions:
 will be deleted when the connection is closed.
 \item \code{":memory:"} or \code{"file::memory:"} will create a temporary
 in-memory database.
+\item If the optional HTTP VFS is available, remote read-only SQLite
+databases can be opened with \code{\link[=sqliteRemote]{sqliteRemote()}} or with a SQLite URI
+filename such as
+\code{"file:https://example.org/db.sqlite?vfs=http&immutable=1"} and
+\code{flags = SQLITE_RO}.
 }}
 
 \item{loadable.extensions}{When \code{TRUE} (default) SQLite3


### PR DESCRIPTION
## Summary
Clarify the two supported entry points for remote read-only SQLite databases over the HTTP VFS.

## Thanks to maintainers
Thanks for adding the HTTP VFS support in #680.

## Issue or motivation
Closes #505. The feature now exists, but the most discoverable docs still do not show the current remote-connection entry points together.

## Root cause
The package-level `dbConnect()` docs only described local paths and memory databases, and the README did not show a minimal current example for either `sqliteRemote()` or the explicit `file:https://...?...` URI form.

## Change
- add a remote-HTTP-VFS bullet to the `dbname` documentation for `dbConnect()`
- add README examples for `sqliteRemote()` and the explicit SQLite URI plus `SQLITE_RO`
- regenerate `man/SQLite.Rd` and sync `README.md`

## Tests
- `git diff --check`
- `Rscript -e 'tools::checkRd("man/SQLite.Rd")'`
- `R CMD build --no-build-vignettes .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests RSQLite_3.53.2.9006.tar.gz`

## Scope
I did not change HTTP VFS behavior, add new helpers, or touch NEWS/tests. This PR only tightens user-facing documentation around the existing feature.
