### PR TITLE
ci(rcc-dev): install dev package deps from P3M instead of patching `Suggests`

### DIFF
--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -125,7 +125,42 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          remotes::install_runiverse("${{ matrix.package }}", linux_distro = "noble")
+          pkg <- "${{ matrix.package }}"
+
+          # P3M (Posit Package Manager) binary repo, used for released deps in step 2.
+          p3m <- Sys.getenv("RSPM")
+          if (!nzchar(p3m)) p3m <- "https://packagemanager.posit.co/cran/__linux__/noble/latest"
+
+          # 1. Install ONLY the dev package from its r-universe repo, WITHOUT
+          #    dependencies. `linux_distro = "noble"` is kept so we pull a fast
+          #    *binary* build from r-universe rather than compiling from source.
+          #    CAVEAT: r-universe has renamed its Linux binary distro from
+          #    "noble" to "resolute", so this hardcoded value can start returning
+          #    404 for some packages (it already broke a dev `tidyr` install).
+          #    Kept for now to preserve binary installs; update or drop
+          #    `linux_distro` once it 404s.
+          remotes::install_runiverse(pkg, dependencies = FALSE, linux_distro = "noble")
+
+          # 2. The dev package may declare NEW hard dependencies that its released
+          #    version (installed earlier from P3M by the pak step) lacks -- e.g.
+          #    dev DBItest added `purrr`, dev `tidyr` links to `cpp11`. Read them
+          #    off the freshly installed dev package and install the missing ones
+          #    from P3M, so dependencies come in as *released* binaries instead of
+          #    dragging dev versions of the whole tree from r-universe. Set repos
+          #    explicitly because step 1 may have pointed them at r-universe.
+          deps <- tools::package_dependencies(
+            pkg,
+            db = installed.packages(),
+            which = c("Depends", "Imports", "LinkingTo")
+          )[[pkg]]
+          deps <- setdiff(deps, rownames(installed.packages()))
+          if (length(deps)) install.packages(deps, repos = p3m)
+
+          # 3. Re-install the dev package from r-universe with dependencies = TRUE.
+          #    Its hard deps are now satisfied from P3M, so this only ensures the
+          #    dev package itself is in place and fills any residual gaps, without
+          #    pulling the entire dependency tree from r-universe.
+          remotes::install_runiverse(pkg, dependencies = TRUE, linux_distro = "noble")
         shell: Rscript {0}
 
       - name: Session info

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Suggests:
     httpuv,
     knitr,
     magrittr,
+    purrr,
     rmarkdown,
     rvest,
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,6 @@ Suggests:
     httpuv,
     knitr,
     magrittr,
-    purrr,
     rmarkdown,
     rvest,
     testthat (>= 3.0.0),


### PR DESCRIPTION
## Problem

The scheduled **`rcc dev`** workflow (`.github/workflows/R-CMD-check-dev.yaml`) fails at the R CMD check step with ~300 test failures:

```
Error in `loadNamespace(x)`: there is no package called 'purrr'
...
[ FAIL 304 | WARN 6 | SKIP 62 | PASS 2750 ]
Error:
! Test failures.
Execution halted
```

## Root cause

The failure was in the workflow, not the package. The "Install dev version" step ran:

```r
remotes::install_runiverse("<pkg>", linux_distro = "noble")
```

`install_runiverse()` installs the **dev package** but does **not** pull the new hard dependencies that dev version may declare. Dev `DBItest` (>= `1.8.2.9020`) moved `purrr` into its **Imports** and calls `purrr::map_lgl()` / `purrr::map()` in its internal `stream_frame()` helper (`DBItest/R/spec-arrow.R`), which backs every Arrow spec test. Since `purrr` was never installed, every Arrow roundtrip spec errored with `there is no package called 'purrr'`, and the ~300 failures pushed the run past testthat's limit and aborted R CMD check.

Adding `purrr` to `Suggests` (the previous version of this PR) only masked this one instance — the next dev dependency a checked package adds would break the run again. The fix belongs in the workflow.

## Fix

Replace the single-line install step with a **three-phase install** that provisions whatever hard dependencies the dev package declares, sourcing them as released binaries from P3M (Posit Package Manager) rather than dragging the whole dev tree from r-universe:

1. **Install the dev package alone** with `dependencies = FALSE`, keeping `linux_distro = "noble"` so we still get the fast r-universe *binary* build instead of compiling from source.
2. **Provision new hard deps from P3M**: read the freshly installed dev package's `Depends` / `Imports` / `LinkingTo`, diff against what's already installed, and `install.packages()` the missing ones from P3M (with `repos` set explicitly, since step 1 may have pointed repos at r-universe). This is what brings in dev `DBItest`'s `purrr`, dev `tidyr`'s `cpp11`, etc. — as released binaries.
3. **Re-install the dev package** with `dependencies = TRUE` to ensure it's in place and fill any residual gaps, now that its hard deps are already satisfied.

The `purrr`-in-`Suggests` workaround has been **reverted** from `DESCRIPTION`.

### `noble` caveat

`linux_distro = "noble"` is retained to preserve fast binary installs, but r-universe has renamed its Linux binary distro from **`noble`** to **`resolute`**. The hardcoded value can therefore start returning **404** for some packages (it already broke a dev `tidyr` install). It's kept for now to keep binary installs working; `linux_distro` should be updated or dropped once it starts 404ing. This is documented inline in the workflow.

## Verification

The `rcc dev` workflow only triggers on schedule / `cran-*` / tags / manual dispatch, not on PR branches. A manual `workflow_dispatch` run has been triggered against this branch to confirm the fix on the CI runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7